### PR TITLE
fixed conflicting names between app envs vs kube envs

### DIFF
--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/application.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/application.conf
@@ -1,14 +1,14 @@
 attributes.service.config = {
   host=localhost
-  host=${?ATTRIBUTE_SERVICE_HOST}
+  host=${?ATTRIBUTE_SERVICE_HOST_CONFIG}
   port=9012
-  port=${?ATTRIBUTE_SERVICE_PORT}
+  port=${?ATTRIBUTE_SERVICE_PORT_CONFIG}
 }
 entity.service.config = {
   host=localhost
-  host=${?ENTITY_SERVICE_HOST}
+  host=${?ENTITY_SERVICE_HOST_CONFIG}
   port=50061
-  port=${?ENTITY_SERVICE_PORT}
+  port=${?ENTITY_SERVICE_PORT_CONFIG}
 }
 dataStoreType = mongo
 mongo = {


### PR DESCRIPTION
- Kube adds default env for port as `ATTRIBUTE_SERVICE_PORT`, so we are adding the suffix `_CONFIG` for app-related host/port config