### PR TITLE
exposes bootstrap runner to be used by other project

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -132,7 +132,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.1.3")
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.1.9")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.1.3")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.logging.log4j:log4j-api:2.13.3")

--- a/config-bootstrapper/src/main/java/org/hypertrace/core/bootstrapper/ConfigBootstrapper.java
+++ b/config-bootstrapper/src/main/java/org/hypertrace/core/bootstrapper/ConfigBootstrapper.java
@@ -19,16 +19,16 @@ public class ConfigBootstrapper {
 
   public static void main(String[] args) {
     updateRuntime();
-    bootstrapper(args);
+    BootstrapArgs bootstrapArgs = BootstrapArgs.from(args);
+    bootstrapper(bootstrapArgs).execute(bootstrapArgs);
   }
 
-  private static void bootstrapper(String[] args) {
-    BootstrapArgs bootstrapArgs = BootstrapArgs.from(args);
+  public static BootstrapRunner bootstrapper(BootstrapArgs bootstrapArgs) {
     Config config = ConfigFactory.parseFile(new File(bootstrapArgs.getConfigFile())).resolve();
     String dataStoreType = config.getString(DocumentStoreConfig.DATASTORE_TYPE_CONFIG_KEY);
     Datastore datastore =
         DatastoreProvider.getDatastore(dataStoreType, config.getConfig(dataStoreType));
-    new BootstrapRunner(new ConfigBootstrapStatusDao(datastore)).execute(bootstrapArgs);
+    return new BootstrapRunner(new ConfigBootstrapStatusDao(datastore));
   }
 
   private static void updateRuntime() {

--- a/config-bootstrapper/src/main/java/org/hypertrace/core/bootstrapper/ConfigBootstrapper.java
+++ b/config-bootstrapper/src/main/java/org/hypertrace/core/bootstrapper/ConfigBootstrapper.java
@@ -23,6 +23,10 @@ public class ConfigBootstrapper {
     bootstrapper(bootstrapArgs).execute(bootstrapArgs);
   }
 
+  /**
+   * Helps in running bootstrapping as a background task in non-concurrent mode.
+   * <p> e.g It is used in https://github.com/hypertrace/hypertrace-federated-service
+   * */
   public static BootstrapRunner bootstrapper(BootstrapArgs bootstrapArgs) {
     Config config = ConfigFactory.parseFile(new File(bootstrapArgs.getConfigFile())).resolve();
     String dataStoreType = config.getString(DocumentStoreConfig.DATASTORE_TYPE_CONFIG_KEY);


### PR DESCRIPTION
Currently, the bootstrap runner is used only as a command-line tool, refactoring a bit to expose to other projects. So, it can be used from `federated` service as background tasks to create attributes.

This will help in the reduction of the container in the local setup mode of HT. 
