### PR TITLE
feat: Upgrading docstore version to upgrade mongo java driver.

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -131,8 +131,8 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.3.0")
   implementation("org.hypertrace.entity.service:entity-service-api:0.3.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.7.0")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.4.3")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.7.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
 

--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -129,12 +129,12 @@ tasks.test {
 }
 
 dependencies {
-  implementation("org.hypertrace.entity.service:entity-service-client:0.1.26")
-  implementation("org.hypertrace.entity.service:entity-service-api:0.1.26")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
+  implementation("org.hypertrace.entity.service:entity-service-client:0.3.0")
+  implementation("org.hypertrace.entity.service:entity-service-api:0.3.0")
+  implementation("org.hypertrace.core.documentstore:document-store:0.7.0")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.4.3")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.logging.log4j:log4j-api:2.13.3")
@@ -143,8 +143,8 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient:4.5.13")
   implementation ("commons-io:commons-io:2.6")
   implementation("com.typesafe:config:1.4.0")
-  implementation("com.google.protobuf:protobuf-java:3.12.2")
-  implementation("com.google.protobuf:protobuf-java-util:3.12.2")
+  implementation("com.google.protobuf:protobuf-java:3.13.0")
+  implementation("com.google.protobuf:protobuf-java-util:3.13.0")
   implementation("commons-cli:commons-cli:1.4")
   implementation("org.reflections:reflections:0.9.12")
   implementation("io.grpc:grpc-netty:1.33.0")
@@ -153,6 +153,12 @@ dependencies {
 
   runtimeOnly("io.netty:netty-handler-proxy:4.1.53.Final") {
     because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
+  }
+
+  constraints {
+    implementation("com.google.guava:guava:30.0-jre") {
+      because("Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@29.0-android")
+    }
   }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")

--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -131,7 +131,7 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.1.26")
   implementation("org.hypertrace.entity.service:entity-service-api:0.1.26")
-  implementation("org.hypertrace.core.documentstore:document-store:0.3.2")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.4.3")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.0")


### PR DESCRIPTION
## Description
Upgrading the docstore version to latest, which changes the mongo java driver used from 3.12 to 4.1.1. This is because the previous java driver is very old, marked legacy driver by MongoDB and there are a lot of bug fixes in the newer versions.

Most importantly, we are running into some issues with bulk upsert in production and we're trying to see if we see those same issues with the latest Mongo java driver too.

### Testing
Ran Hypertrace locally with the locally built image and things are working fine.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
No functionality is changed, hence no docs needed.
