### PR TITLE
Upgrading docstore version to add support for postgres

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -129,10 +129,10 @@ tasks.test {
 }
 
 dependencies {
-  implementation("org.hypertrace.entity.service:entity-service-client:0.3.0")
-  implementation("org.hypertrace.entity.service:entity-service-api:0.3.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.7.0")
+  implementation("org.hypertrace.entity.service:entity-service-client:0.4.1")
+  implementation("org.hypertrace.entity.service:entity-service-api:0.4.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.4")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.8.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")
 


### PR DESCRIPTION
Upgrading docstore version to add support for postgres(hypertrace/document-store#9)
