### PR TITLE
adding helm configs for postgres

### DIFF
--- a/helm/templates/config-bootstrapper-config.yaml
+++ b/helm/templates/config-bootstrapper-config.yaml
@@ -14,12 +14,32 @@ data:
         host={{ .Values.entityServiceConfig.data.host }}
         port={{ .Values.entityServiceConfig.data.port }}
     }
-    dataStoreType = mongo
+    dataStoreType = {{ .Values.dataStoreType }}
+    {{- if eq .Values.dataStoreType "mongo" }}
     mongo = {
-      {{- if .Values.mongoConfig.data.url }}
-      url = {{ .Values.mongoConfig.data.url | quote }}
-      {{- else }}
-      host={{ .Values.mongoConfig.data.host }}
-      port={{ .Values.mongoConfig.data.port }}
-      {{- end }}
-    }
+          {{- if .Values.mongoConfig.data.url }}
+          url = {{ .Values.mongoConfig.data.url | quote }}
+          {{- else }}
+          host={{ .Values.mongoConfig.data.host }}
+          port={{ .Values.mongoConfig.data.port }}
+          {{- end }}
+        }
+    {{ else if eq .Values.dataStoreType "postgres" }}
+    postgres = {
+          {{- if .Values.postgresConfig.data.url }}
+          url={{ .Values.postgresConfig.data.url | quote }}
+          {{- else }}
+          host={{ .Values.postgresConfig.data.host }}
+          port={{ .Values.postgresConfig.data.port }}
+          {{- end }}
+          {{- if .Values.postgresConfig.data.database }}
+          database= {{ .Values.postgresConfig.data.database }}
+          {{- end }}
+          {{- if .Values.postgresConfig.data.user }}
+          user={{ .Values.postgresConfig.data.user }}
+          {{- end }}
+          {{- if .Values.postgresConfig.data.password }}
+          password={{ .Values.postgresConfig.data.password }}
+          {{- end }}
+        }
+    {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,11 +77,19 @@ attributeServiceConfig:
     host: attribute-service
     port: 9012
 
+dataStoreType: "mongo"
 mongoConfig:
   name: mongo-config
   data:
     host: mongo
     port: 27017
+    url: ""
+
+postgresConfig:
+  name: postgres-config
+  data:
+    host: postgres
+    port: 5432
     url: ""
 
 logConfig:


### PR DESCRIPTION
## Description
Adds helm configs for enabling support for postgres (see more details at https://github.com/hypertrace/hypertrace/issues/124)

### Testing
Generate the helm templates locally using the command - `helm template ./helm/` for various cases
- dataStoreType: "postgres"
- dataStoreType: "mongo"

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
This specific change may not require, but when we update in docker-compose for postgres, we will document it.
