### PR TITLE
chore:updates service framework version

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -167,6 +167,6 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
   testImplementation("org.mockito:mockito-core:3.3.3")
 
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.18")
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.19")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
 }


### PR DESCRIPTION
Updates the latest version of the service framework for integration test. (Ref issue which upgrades service framework: https://github.com/hypertrace/hypertrace/issues/137)