### PR TITLE
Support running multiple jobs

### DIFF
--- a/helm/templates/bootstrap-configs.yaml
+++ b/helm/templates/bootstrap-configs.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.job.prefix "default" }}
+{{ if .Values.jobs.default }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/bootstrap-configs.yaml
+++ b/helm/templates/bootstrap-configs.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.jobs.default }}
+{{ if .Values.jobs.default.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/templates/config-bootstrapper-config.yaml
+++ b/helm/templates/config-bootstrapper-config.yaml
@@ -1,45 +1,49 @@
+{{ $global := . }}
+{{- range $k, $job := .Values.jobs }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.job.prefix }}-{{ .Values.configBootstrapperConfig.name }}
+  name: {{ $job.prefix }}-{{ $global.Values.configBootstrapperConfig.name }}
   labels:
-    release: {{ .Release.Name }}
+    release: {{ $global.Release.Name }}
 data:
   application.conf: |-
     attributes.service.config = {
-        host={{ .Values.attributeServiceConfig.data.host }}
-        port={{ .Values.attributeServiceConfig.data.port }}
+        host={{ $global.Values.attributeServiceConfig.data.host }}
+        port={{ $global.Values.attributeServiceConfig.data.port }}
     }
     entity.service.config = {
-        host={{ .Values.entityServiceConfig.data.host }}
-        port={{ .Values.entityServiceConfig.data.port }}
+        host={{ $global.Values.entityServiceConfig.data.host }}
+        port={{ $global.Values.entityServiceConfig.data.port }}
     }
-    dataStoreType = {{ .Values.dataStoreType }}
-    {{- if eq .Values.dataStoreType "mongo" }}
+    dataStoreType = {{ $global.Values.dataStoreType }}
+    {{- if eq $global.Values.dataStoreType "mongo" }}
     mongo = {
-          {{- if .Values.mongoConfig.data.url }}
-          url = {{ .Values.mongoConfig.data.url | quote }}
+          {{- if $global.Values.mongoConfig.data.url }}
+          url = {{ $global.Values.mongoConfig.data.url | quote }}
           {{- else }}
-          host={{ .Values.mongoConfig.data.host }}
-          port={{ .Values.mongoConfig.data.port }}
+          host={{ $global.Values.mongoConfig.data.host }}
+          port={{ $global.Values.mongoConfig.data.port }}
           {{- end }}
         }
-    {{ else if eq .Values.dataStoreType "postgres" }}
+    {{ else if eq $global.Values.dataStoreType "postgres" }}
     postgres = {
-          {{- if .Values.postgresConfig.data.url }}
-          url={{ .Values.postgresConfig.data.url | quote }}
+          {{- if $global.Values.postgresConfig.data.url }}
+          url={{ $global.Values.postgresConfig.data.url | quote }}
           {{- else }}
-          host={{ .Values.postgresConfig.data.host }}
-          port={{ .Values.postgresConfig.data.port }}
+          host={{ $global.Values.postgresConfig.data.host }}
+          port={{ $global.Values.postgresConfig.data.port }}
           {{- end }}
-          {{- if .Values.postgresConfig.data.database }}
-          database= {{ .Values.postgresConfig.data.database }}
+          {{- if $global.Values.postgresConfig.data.database }}
+          database= {{ $global.Values.postgresConfig.data.database }}
           {{- end }}
-          {{- if .Values.postgresConfig.data.user }}
-          user={{ .Values.postgresConfig.data.user }}
+          {{- if $global.Values.postgresConfig.data.user }}
+          user={{ $global.Values.postgresConfig.data.user }}
           {{- end }}
-          {{- if .Values.postgresConfig.data.password }}
-          password={{ .Values.postgresConfig.data.password }}
+          {{- if $global.Values.postgresConfig.data.password }}
+          password={{ $global.Values.postgresConfig.data.password }}
           {{- end }}
         }
     {{- end }}
+{{- end }}

--- a/helm/templates/config-bootstrapper-config.yaml
+++ b/helm/templates/config-bootstrapper-config.yaml
@@ -1,5 +1,6 @@
 {{ $global := . }}
 {{- range $k, $job := .Values.jobs }}
+{{ if $job.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -46,4 +47,5 @@ data:
           {{- end }}
         }
     {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -1,10 +1,13 @@
+{{ $global := . }}
+{{- range $k, $job := .Values.jobs }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Values.job.prefix }}-{{ .Chart.Name }}
+  name: {{ $job.prefix }}-{{ $global.Chart.Name }}
   labels:
-    release: {{ .Release.Name }}
-  {{- with .Values.jobLabels }}
+    release: {{ $global.Release.Name }}
+  {{- with $global.Values.jobLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   annotations:
@@ -18,75 +21,76 @@ spec:
   template:
     metadata:
       labels:
-        release: {{ .Release.Name }}
-      {{- with .Values.podLabels }}
+        release: {{ $global.Release.Name }}
+      {{- with $global.Values.podLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       restartPolicy: OnFailure
-    {{- with .Values.imagePullSecrets }}
+    {{- with $global.Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}
     {{- end }}
       volumes:
         - name: job-config
           configMap:
-            name: {{ .Values.job.prefix }}-{{ .Values.configBootstrapperConfig.name }}
+            name: {{ $job.prefix }}-{{ $global.Values.configBootstrapperConfig.name }}
         - name: log4j-config
           configMap:
-            name: {{ .Values.job.prefix }}-{{ .Values.logConfig.name }}
-        {{- if .Values.configurationCommands }}
+            name: {{ $job.prefix }}-{{ $global.Values.logConfig.name }}
+        {{- if $global.Values.configurationCommands }}
         - name: bootstrap-configs
           configMap:
-            name: {{ .Values.job.prefix }}-bootstrap-configs
+            name: {{ $job.prefix }}-bootstrap-configs
         {{- end }}
-    {{- with .Values.nodeLabels }}
+    {{- with $global.Values.nodeLabels }}
       nodeSelector:
       {{- toYaml . | nindent 8}}
     {{- end }}
       initContainers:
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") }}
+        {{- if or (eq $job.prefix "default") (eq $job.prefix "attribute") }}
         - name: attribute-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
-          args: ["until nc -zv {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}; \
-                  do echo 'waiting for {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}'; \
+          args: ["until nc -zv {{ $global.Values.attributeServiceConfig.data.host }} {{ $global.Values.attributeServiceConfig.data.port }}; \
+                  do echo 'waiting for {{ $global.Values.attributeServiceConfig.data.host }} {{ $global.Values.attributeServiceConfig.data.port }}'; \
                   sleep 5; done"]
         {{- end }}
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") }}
+        {{- if or (eq $job.prefix "default") (eq $job.prefix "entity") }}
         - name: entity-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
-          args: ["until nc -zv {{ .Values.entityServiceConfig.data.host }} {{ .Values.entityServiceConfig.data.port }}; \
-                  do echo 'waiting for {{ .Values.entityServiceConfig.data.host }} {{ .Values.entityServiceConfig.data.port }}'; \
+          args: ["until nc -zv {{ $global.Values.entityServiceConfig.data.host }} {{ $global.Values.entityServiceConfig.data.port }}; \
+                  do echo 'waiting for {{ $global.Values.entityServiceConfig.data.host }} {{ $global.Values.entityServiceConfig.data.port }}'; \
                   sleep 5; done"]
         {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper/{{ .Values.job.prefix }}-service", "--upgrade" ]
+        - name: {{ $global.Chart.Name }}
+          image: "{{ $global.Values.image.repository }}:{{ $global.Chart.AppVersion }}"
+          imagePullPolicy: {{ $global.Values.image.pullPolicy }}
+          args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper/{{ $job.prefix }}-service", "--upgrade" ]
           env:
             - name: SERVICE_NAME
-              value: "{{ .Chart.Name }}"
+              value: "{{ $global.Chart.Name }}"
             - name: LOG4J_CONFIGURATION_FILE
-              value: "/var/{{ .Chart.Name }}/log/log4j2.properties"
+              value: "/var/{{ $global.Chart.Name }}/log/log4j2.properties"
             - name: JAVA_TOOL_OPTIONS
-              value: {{ .Values.javaOpts | quote }}
+              value: {{ $global.Values.javaOpts | quote }}
           volumeMounts:
             - name: job-config
               mountPath: /etc/config-bootstrapper/application.conf
               subPath: application.conf
             - name: log4j-config
-              mountPath: /var/{{ .Chart.Name }}/log
-            {{- range $key, $value := .Values.configurationCommands }}
+              mountPath: /var/{{ $global.Chart.Name }}/log
+            {{- range $key, $value := $job.configurationCommands }}
             - name: bootstrap-configs
-              mountPath: /app/resources/configs/config-bootstrapper/{{ $.Values.job.prefix }}-service/extras/{{ $key }}
+              mountPath: /app/resources/configs/config-bootstrapper/{{ $job.prefix }}-service/extras/{{ $key }}
               subPath: {{ $key }}
             {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml $global.Values.resources | nindent 12 }}
 
   backoffLimit: 100
+{{- end }}

--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -1,5 +1,6 @@
 {{ $global := . }}
 {{- range $k, $job := .Values.jobs }}
+{{ if $job.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -93,4 +94,5 @@ spec:
             {{- toYaml $global.Values.resources | nindent 12 }}
 
   backoffLimit: 100
+{{- end }}
 {{- end }}

--- a/helm/templates/logconfig.yaml
+++ b/helm/templates/logconfig.yaml
@@ -1,9 +1,12 @@
+{{ $global := . }}
+{{- range $k, $job := .Values.jobs }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.job.prefix }}-{{ .Values.logConfig.name }}
+  name: {{ $job.prefix }}-{{ $global.Values.logConfig.name }}
   labels:
-    release: {{ .Release.Name }}
+    release: {{ $global.Release.Name }}
 data:
   log4j2.properties: |-
     status = error
@@ -14,7 +17,7 @@ data:
     appender.console.layout.type = PatternLayout
     appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %c{1.} - %msg%n
 
-    {{- if .Values.logConfig.appender.rolling.enabled }}
+    {{- if $global.Values.logConfig.appender.rolling.enabled }}
     appender.rolling.type = RollingFile
     appender.rolling.name = ROLLING_FILE
     appender.rolling.fileName = ${env:SERVICE_NAME:-service}.log
@@ -31,8 +34,9 @@ data:
     appender.rolling.strategy.max = 5
     {{- end }}
 
-    rootLogger.level = {{ .Values.logConfig.rootLogger.level }}
+    rootLogger.level = {{ $global.Values.logConfig.rootLogger.level }}
     rootLogger.appenderRef.stdout.ref = STDOUT
-    {{- if .Values.logConfig.appender.rolling.enabled }}
+    {{- if $global.Values.logConfig.appender.rolling.enabled }}
     rootLogger.appenderRef.rolling.ref = ROLLING_FILE
     {{- end }}
+{{- end }}

--- a/helm/templates/logconfig.yaml
+++ b/helm/templates/logconfig.yaml
@@ -1,5 +1,6 @@
 {{ $global := . }}
 {{- range $k, $job := .Values.jobs }}
+{{ if $job.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -40,3 +41,5 @@ data:
     rootLogger.appenderRef.rolling.ref = ROLLING_FILE
     {{- end }}
 {{- end }}
+{{- end }}
+

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -60,10 +60,10 @@ serviceSelectorLabels:
 configBootstrapperConfig:
   name: config-bootstrapper-config
 
-job:
-  prefix: default
-
-configurationCommands: {}
+jobs:
+  default:
+    prefix: default
+    configurationCommands: {}
 
 entityServiceConfig:
   name: entity-service-config

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -63,6 +63,7 @@ configBootstrapperConfig:
 jobs:
   default:
     prefix: default
+    enabled: true
     configurationCommands: {}
 
 entityServiceConfig:


### PR DESCRIPTION
Config bootstrapping job is used by entity and attribute service 
In the parent chart, following block has to be provided:
```
config-bootstrapper:
  job:
    prefix: <attribute or entity>
  configurationCommands: {} 
```

I ran into an use case (here https://github.com/hypertrace/hypertrace-service/pull/66/files#diff-34e6fca01efdbade1fa38024afd3860d5fc9b50a177cd884324700c624c8cfdfR126), where both entity and attribute config bootstrapping job had to be run by the the same parent
So, the change is to allow parent chart to trigger multiple bootstrap jobs, ex:
```
config-bootstrapper:
  jobs:
    default:
      enabled: false
    attribute:
      prefix: attribute
      enabled: true
      configurationCommands: {}
    entity:
      prefix: entity
      enabled: true
      configurationCommands: {}
```

Pr for updating consumers:
https://github.com/hypertrace/attribute-service/pull/69
https://github.com/hypertrace/entity-service/pull/77