### PR TITLE
Support for running attribute and entity bootstrap together 

### DIFF
--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -45,7 +45,7 @@ spec:
       {{- toYaml . | nindent 8}}
     {{- end }}
       initContainers:
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "attribute-entity") }}
         - name: attribute-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
@@ -54,7 +54,7 @@ spec:
                   do echo 'waiting for {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}'; \
                   sleep 5; done"]
         {{- end }}
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "attribute-entity") }}
         - name: entity-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
@@ -67,7 +67,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if (eq .Values.job.prefix "attribute-entity") }}
+          args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper", "--upgrade" ]
+        {{- else }}
           args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper/{{ .Values.job.prefix }}-service", "--upgrade" ]
+        {{- end }}
           env:
             - name: SERVICE_NAME
               value: "{{ .Chart.Name }}"

--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -45,7 +45,7 @@ spec:
       {{- toYaml . | nindent 8}}
     {{- end }}
       initContainers:
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "attribute-and-entity") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "all") }}
         - name: attribute-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
@@ -54,7 +54,7 @@ spec:
                   do echo 'waiting for {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}'; \
                   sleep 5; done"]
         {{- end }}
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "attribute-and-entity") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "all") }}
         - name: entity-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
@@ -67,7 +67,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if (eq .Values.job.prefix "attribute-and-entity") }}
+        {{- if (eq .Values.job.prefix "all") }}
           args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper", "--upgrade" ]
         {{- else }}
           args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper/{{ .Values.job.prefix }}-service", "--upgrade" ]

--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -54,7 +54,7 @@ spec:
                   do echo 'waiting for {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}'; \
                   sleep 5; done"]
         {{- end }}
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "attribute-entity") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "attribute-and-entity") }}
         - name: entity-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent
@@ -67,7 +67,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if (eq .Values.job.prefix "attribute-entity") }}
+        {{- if (eq .Values.job.prefix "attribute-and-entity") }}
           args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper", "--upgrade" ]
         {{- else }}
           args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper/{{ .Values.job.prefix }}-service", "--upgrade" ]

--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -45,7 +45,7 @@ spec:
       {{- toYaml . | nindent 8}}
     {{- end }}
       initContainers:
-        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "attribute-entity") }}
+        {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "attribute-and-entity") }}
         - name: attribute-service-ready
           image: busybox
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Instead of running two separate jobs for entity & attribute bootstrapping (proposed here https://github.com/hypertrace/config-bootstrapper/pull/33)
This pr adds a new job prefix called `attribute-entity`, for this job the program argument will be
```
args: [ "-c", "/etc/config-bootstrapper/application.conf", "-C", "/app/resources/configs/config-bootstrapper", "--upgrade" ]
```
which allows it to read both entity & attribute configs passed 
```
├── application.conf
├── attribute-service
│   ├── hypertrace
│   │   ├── hypertrace_api_attributes.conf
│   │   ├── hypertrace_api_trace_attributes.conf
│   │   ├── hypertrace_backend_attributes.conf
│   │   ├── hypertrace_backend_trace_attributes.conf
│   │   ├── hypertrace_interaction_attributes.conf
│   │   ├── hypertrace_service_attributes.conf
│   │   └── hypertrace_span_attributes.conf
│   └── hypertrace-core
│       ├── 1_event_attributes.conf
│       └── 1_trace_attributes.conf
└── entity-service
    └── hypertrace
        ├── 1_entityrelationshiptypes.conf
        └── 1_entitytypes.conf
```

Have verified this change, locally by locally building the chart and testing with https://github.com/hypertrace/hypertrace-service/pull/66/files#diff-34e6fca01efdbade1fa38024afd3860d5fc9b50a177cd884324700c624c8cfdfR128