### PR TITLE
chore: bump doc-store version to include sqli fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
       - '*':
           reason: No replacement available
-          expires: 2021-01-31T00:00:00.000Z
+          expires: 2021-02-28T00:00:00.000Z
 patch: {}

--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -131,7 +131,7 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.4.1")
   implementation("org.hypertrace.entity.service:entity-service-api:0.4.1")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.4")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.8.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")


### PR DESCRIPTION
Updates doc-store version to include sqli fix - https://github.com/hypertrace/document-store/pull/30
