### PR TITLE
chore: bump version of netty proxy libs to fix the vulnerability

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -151,16 +151,13 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind:2.11.1")
 
   runtimeOnly("io.grpc:grpc-netty:1.33.0")
-
+  runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
   constraints {
     implementation("com.google.guava:guava:30.0-jre") {
       because("Information Disclosure [Medium Severity][https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415] in com.google.guava:guava@29.0-android")
     }
     implementation("commons-codec:commons-codec:1.15") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518")
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.53.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
     }
   }
 


### PR DESCRIPTION
Updates version of libs for netty to address,
- https://github.com/hypertrace/config-bootstrapper/runs/1868684886?check_suite_focus=true
- https://snyk.io/vuln/SNYK-JAVA-IONETTY-1070799