### PR TITLE
chore: bump doc-store version to include postgres impl of exits, not-exists and neq

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -131,7 +131,7 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.4.1")
   implementation("org.hypertrace.entity.service:entity-service-api:0.4.1")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.8.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.3.1")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.3.1")


### PR DESCRIPTION
Updates doc-store version to include postgres impl of exists, not-exists, and NEQ filters

- hypertrace/document-store#35
- hypertrace/document-store#33