### PR TITLE
fix: update post hook annotation for config maps

### DIFF
--- a/helm/templates/bootstrap-configs.yaml
+++ b/helm/templates/bootstrap-configs.yaml
@@ -5,6 +5,8 @@ metadata:
   name:  default-bootstrap-configs
   labels:
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
 data:
 {{- range $path, $bytes := .Files.Glob "configs/**" }}
 {{- $name := base ($path) }}

--- a/helm/templates/config-bootstrapper-config.yaml
+++ b/helm/templates/config-bootstrapper-config.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ .Values.job.prefix }}-{{ .Values.configBootstrapperConfig.name }}
   labels:
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
 data:
   application.conf: |-
     attributes.service.config = {


### PR DESCRIPTION
Fix the post hook annotation for config map, this requires as while generating post-installation manifest files, it only copies the job, but it misses configmap - https://github.com/hypertrace/hypertrace/tree/main/kubernetes#create-deployment-manigests. 