### PR TITLE
chore: adds api_trace_error_span_count attribute

### DIFF
--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_api_trace_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_api_trace_attributes.conf
@@ -226,6 +226,15 @@ commands = [
               scope: API_TRACE,
               sources: [QS],
               type: ATTRIBUTE
+            },
+            {
+              fqn: Api.Trace.api_trace_error_span_count,
+              key: apiTraceErrorSpanCount,
+              value_kind: TYPE_INT64,
+              display_name: Api Trace Error Span Count,
+              scope: API_TRACE,
+              sources: [QS],
+              type: ATTRIBUTE
             }
           ]
         }


### PR DESCRIPTION
## Description
Adds api_trace_error_count attribute as per changes here: hypertrace/hypertrace-ingester#172

### Testing
NA

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

