### PR TITLE
chore: update attr client

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -60,7 +60,7 @@ tasks.register<DockerStopContainer>("stopMongoContainer") {
 }
 
 tasks.register<DockerPullImage>("pullAttributeServiceImage") {
-  image.set("hypertrace/attribute-service:0.11.0")
+  image.set("hypertrace/attribute-service:0.12.0")
 }
 
 tasks.register<DockerCreateContainer>("createAttributeServiceContainer") {
@@ -129,7 +129,7 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
   implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
-  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.11.0")
+  implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
 


### PR DESCRIPTION
## Description
Update attr version to bring in https://github.com/hypertrace/attribute-service/releases/tag/0.12.0 (specifically, the API additions from https://github.com/hypertrace/attribute-service/pull/93 )
