### PR TITLE
Parameterize initContainers image

### DIFF
--- a/helm/templates/job.yaml
+++ b/helm/templates/job.yaml
@@ -47,7 +47,7 @@ spec:
       initContainers:
         {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "attribute") (eq .Values.job.prefix "all") }}
         - name: attribute-service-ready
-          image: busybox
+          image: {{ .Values.initContainers.image.repository }}
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args: ["until nc -zv {{ .Values.attributeServiceConfig.data.host }} {{ .Values.attributeServiceConfig.data.port }}; \
@@ -56,7 +56,7 @@ spec:
         {{- end }}
         {{- if or (eq .Values.job.prefix "default") (eq .Values.job.prefix "entity") (eq .Values.job.prefix "all") }}
         - name: entity-service-ready
-          image: busybox
+          image: {{ .Values.initContainers.image.repository }}
           imagePullPolicy: IfNotPresent
           command: ["sh", "-c"]
           args: ["until nc -zv {{ .Values.entityServiceConfig.data.host }} {{ .Values.entityServiceConfig.data.port }}; \

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,6 +20,10 @@ image:
 
 imagePullSecrets: []
 
+initContainers:
+  image:
+    repository: busybox
+
 nodeLabels: {}
 
 javaOpts: "-Xms256M -Xmx768M"


### PR DESCRIPTION
## Description

Parameterize initContainers image. Even that image is simply busybox enabling configuring the image enable installing from different repo (perhaps company repo) that is not blocked by fw. By default busybox would be fetched from dockerhub that is not always allowed. This PR enables the option to override by [helmfile](https://github.com/roboll/helmfile) for easier orchestration.


### Testing
Tested by `helm template`

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
