### PR TITLE
fix: remove incorrect attributes

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -130,8 +130,8 @@ dependencies {
   implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")
 
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("org.apache.logging.log4j:log4j-api:2.14.1")
@@ -140,29 +140,26 @@ dependencies {
   implementation("org.apache.httpcomponents:httpclient:4.5.13")
   implementation("commons-io:commons-io:2.8.0")
   implementation("com.typesafe:config:1.4.1")
-  implementation("com.google.protobuf:protobuf-java:3.15.8")
-  implementation("com.google.protobuf:protobuf-java-util:3.15.8")
+  implementation("com.google.protobuf:protobuf-java:3.19.1")
+  implementation("com.google.protobuf:protobuf-java-util:3.19.1")
   implementation("commons-cli:commons-cli:1.4")
   implementation("org.reflections:reflections:0.9.12")
   implementation("com.fasterxml.jackson.core:jackson-core:2.12.2")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
 
-  runtimeOnly("io.grpc:grpc-netty:1.37.0")
+  runtimeOnly("io.grpc:grpc-netty:1.42.0")
 
   constraints {
     implementation("commons-codec:commons-codec:1.15") {
       because("https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518")
     }
-    runtimeOnly("io.netty:netty-codec-http2:4.1.68.Final") {
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.68.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1083991")
-    }
+    runtimeOnly("io.netty:netty-codec-http2:4.1.68.Final")
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.68.Final")
   }
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.9.0")
 
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.21")
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.31")
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
 }

--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace-core/hypertrace_core_event_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace-core/hypertrace_core_event_attributes.conf
@@ -28,7 +28,10 @@ commands = [
               scope: EVENT,
               sources: [QS],
               type: ATTRIBUTE,
-              internal: false
+              internal: false,
+              definition: {
+                source_path: SERVICE_NAME
+              }
             },
             {
               fqn: Span.start_time_millis,

--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
@@ -149,48 +149,6 @@ commands = [
               internal: false
             },
             {
-              fqn: Span.attributes.service_name,
-              key: serviceName,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: Service Name,
-              scope: EVENT,
-              sources: [QS],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                source_path: SERVICE_NAME
-              }
-            },
-            {
-              fqn: Span.attributes.domain_id,
-              key: domainId,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: Domain Id,
-              scope: EVENT,
-              sources: [QS],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                source_path: DOMAIN_ID
-              }
-            },
-            {
-              fqn: Span.attributes.domain_name,
-              key: domainName,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: Domain Name,
-              scope: EVENT,
-              sources: [QS],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                source_path: DOMAIN_NAME
-              }
-            },
-            {
               fqn: Span.attributes.http_method,
               key: httpMethod,
               value_kind: TYPE_STRING,

--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
@@ -155,7 +155,7 @@ commands = [
               groupable: true,
               display_name: HTTP Method,
               scope: EVENT,
-              sources: [QS],
+              sources: [],
               internal: true,
               type: ATTRIBUTE,
               definition: {
@@ -178,7 +178,7 @@ commands = [
               groupable: true,
               display_name: HTTP Path,
               scope: EVENT,
-              sources: [QS],
+              sources: [],
               internal: true,
               type: ATTRIBUTE,
               definition: {
@@ -204,7 +204,7 @@ commands = [
               groupable: true,
               display_name: HTTP Url,
               scope: EVENT,
-              sources: [QS],
+              sources: [],
               internal: true,
               type: ATTRIBUTE,
               definition: {
@@ -230,7 +230,7 @@ commands = [
               groupable: true,
               display_name: Endpoint Boundary Type,
               scope: EVENT,
-              sources: [QS],
+              sources: [],
               internal: true,
               type: ATTRIBUTE,
               definition: {
@@ -256,7 +256,7 @@ commands = [
               groupable: true,
               display_name: Endpoint Url Pattern,
               scope: EVENT,
-              sources: [QS],
+              sources: [],
               internal: true,
               type: ATTRIBUTE,
               definition: {


### PR DESCRIPTION
## Description
Removes several incorrectly defined attributes. 
- Service name is a hypertrace core attribute, so does not belong in the hypertrace definition file. Further, the hypertrace override of the definition incorrectly marks this attribute as internal.
- Domain ID and Domain name are not relevant to this project.

### Testing
Updated image locally with change and verified in explorer UI

Closes https://github.com/hypertrace/hypertrace-ui/issues/1287