### PR TITLE
chore: update codecov gha to v2

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,7 +34,7 @@ jobs:
           args: jacocoTestReport
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: unit test reports
           fail_ci_if_error: true
@@ -46,7 +46,7 @@ jobs:
           args: jacocoIntegrationTestReport
   
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: integration test reports
           fail_ci_if_error: true


### PR DESCRIPTION
## Description
Codecov bash uploader is being deprecated and is currently in the brownout phase. We need to upgrade to the v2 gh action in all repos.

More info: https://about.codecov.io/blog/codecov-uploader-deprecation-plan/