### PR TITLE
chore: upgrade document-store lib version to latest

### DIFF
--- a/config-bootstrapper/build.gradle.kts
+++ b/config-bootstrapper/build.gradle.kts
@@ -128,7 +128,7 @@ tasks.test {
 dependencies {
   implementation("org.hypertrace.entity.service:entity-service-client:0.6.4")
   implementation("org.hypertrace.entity.service:entity-service-api:0.6.4")
-  implementation("org.hypertrace.core.documentstore:document-store:0.6.7")
+  implementation("org.hypertrace.core.documentstore:document-store:0.6.14")
   implementation("org.hypertrace.core.attribute.service:attribute-service-client:0.12.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.2")
   implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.2")


### PR DESCRIPTION
- Upgrade the document store lib version and fixed the test to handle upgrade of hypertrace-service (ref : https://github.com/hypertrace/hypertrace-service/pull/123#issuecomment-1070371677)