### PR TITLE
Revert "chore: API external from QS"

### DIFF
--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_api_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_api_attributes.conf
@@ -68,7 +68,7 @@ commands = [
               value_kind: TYPE_BOOL,
               display_name: Is External,
               scope: API,
-              sources: [QS, EDS],
+              sources: [EDS],
               type: ATTRIBUTE,
               internal: false
             },


### PR DESCRIPTION
Reverts hypertrace/config-bootstrapper#79