### PR TITLE
cleanup(hypertrace_event_attributes): invalid attributes

### DIFF
--- a/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
+++ b/config-bootstrapper/src/main/resources/configs/config-bootstrapper/attribute-service/hypertrace/hypertrace_span_attributes.conf
@@ -9,7 +9,7 @@ commands = [
         data: {
           filter = {
             scope: [EVENT]
-            key: [upstreamService, downstreamServices]
+            key: [upstreamService, downstreamServices, httpMethod, httpPath, httpUrl, apiUrlPattern, apiBoundaryType]
           }
         }
       },
@@ -149,95 +149,6 @@ commands = [
               internal: false
             },
             {
-              fqn: Span.attributes.http_method,
-              key: httpMethod,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: HTTP Method,
-              scope: EVENT,
-              sources: [],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                first_value_present: {
-                  definitions: [
-                    {
-                      source_path: http.request.method
-                    },
-                    {
-                      source_path: http.method
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              fqn: Span.attributes.http_path,
-              key: httpPath,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: HTTP Path,
-              scope: EVENT,
-              sources: [],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                first_value_present: {
-                  definitions: [
-                    {
-                      source_path: http.request.path
-                    },
-                    {
-                      source_path: http.path
-                    },
-                    {
-                      source_path: http.target
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              fqn: Span.attributes.http_url,
-              key: httpUrl,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: HTTP Url,
-              scope: EVENT,
-              sources: [],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                first_value_present: {
-                  definitions: [
-                    {
-                      source_path: http.url
-                    },
-                    {
-                      source_path: http.request.url
-                    },
-                    {
-                      source_path: url
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              fqn: Span.attributes.api_boundary_type,
-              key: apiBoundaryType,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: Endpoint Boundary Type,
-              scope: EVENT,
-              sources: [],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                source_path: API_BOUNDARY_TYPE
-              }
-            },
-            {
               fqn: Span.attributes.spans,
               key: spans,
               value_kind: TYPE_INT64,
@@ -248,22 +159,7 @@ commands = [
               supportedAggregations: [COUNT, AVGRATE],
               type: ATTRIBUTE,
               internal: false
-            },
-            {
-              fqn: Span.attributes.api_url_pattern,
-              key: apiUrlPattern,
-              value_kind: TYPE_STRING,
-              groupable: true,
-              display_name: Endpoint Url Pattern,
-              scope: EVENT,
-              sources: [],
-              internal: true,
-              type: ATTRIBUTE,
-              definition: {
-                source_path: API_URL_PATTERN
-              }
-            },
-
+            }
           ]
         }
       }


### PR DESCRIPTION
The attributes aren't being used anywhere (and they don't have any sources, which could cause any UI queries to fail)